### PR TITLE
Fix spelling of "TODO" comment in AssignmentStatement class

### DIFF
--- a/src/main/java/edu/montana/csci/csci468/parser/statements/AssignmentStatement.java
+++ b/src/main/java/edu/montana/csci/csci468/parser/statements/AssignmentStatement.java
@@ -35,7 +35,7 @@ public class AssignmentStatement extends Statement {
         if (symbolType == null) {
             addError(ErrorType.UNKNOWN_NAME);
         } else {
-            // TOOD - verify compatilibity of types
+            // TODO - verify compatilibity of types
         }
     }
 


### PR DESCRIPTION
I use the `TODO` feature in Intellij, and I knew I was missing something but I could not find it. There was a misspelled "TODO" comment.